### PR TITLE
Fix D04 Ex04: replace spation by spatio

### DIFF
--- a/correction_04.md
+++ b/correction_04.md
@@ -280,7 +280,7 @@ and implements two methods.
 Check the result of the following cases:
 ```python
 import pandas as pd
-from SpationTemporalData import SpatioTemporalData
+from SpatioTemporalData import SpatioTemporalData
 import os
 
 df = pd.read_csv(os.environ["CSV_PATH"])


### PR DESCRIPTION
Day 04 Exercice 04

<code>
import pandas as pd 

from SpationTemporalData import SpatioTemporalData

import os

df = pd.read_csv(os.environ["CSV_PATH"])

sp = SpatioTemporalData(df)

print(sp.where(2000))

\# output is: ['Sydney']

print(sp.where(1980))

\# output is: ['Lake Placid', 'Moskva'] If a single of these locations is returned it's ok.

print(sp.when('London'))

\# output is: [2012, 1948, 1908]
</code>

On the second line i replace **Spation** by **Spatio**